### PR TITLE
add: example for podium style reactable

### DIFF
--- a/reactable/podium_style_leaderboard/data/total_points.csv
+++ b/reactable/podium_style_leaderboard/data/total_points.csv
@@ -1,0 +1,33 @@
+country,alpha.2,total_points
+Argentina,AR,18
+Australia,AU,6
+Belgium,BE,4
+Brazil,BR,9
+Cameroon,CM,4
+Canada,CA,0
+Costa Rica,CR,3
+Croatia,HR,14
+Denmark,DK,1
+Ecuador,EC,4
+England,GB,10
+France,FR,15
+Germany,DE,4
+Ghana,GH,3
+Iran,IR,3
+Japan,JP,6
+Korea Republic,KR,4
+Mexico,MX,4
+Morocco,MA,13
+Netherlands,NL,10
+Poland,PL,4
+Portugal,PT,9
+Qatar,QA,0
+Saudi Arabia,SA,3
+Senegal,SN,6
+Serbia,RS,1
+Spain,ES,4
+Switzerland,CH,6
+Tunisia,TN,4
+United States,US,5
+Uruguay,UY,4
+Wales,GB,2

--- a/reactable/podium_style_leaderboard/leaderboard.R
+++ b/reactable/podium_style_leaderboard/leaderboard.R
@@ -1,0 +1,131 @@
+library(shiny)
+library(reactable)
+library(sass)
+
+#' @description simple function to get country emoji
+#' @param country_codes vector of alpha-2 country codes
+#' @return vector with country flag emoji
+#'
+get_flag <- function(country_codes) {
+  sapply(country_codes, function(country_code) {
+    if (is.null(country_code) || is.na(country_code)) {
+      return(NULL)
+    }
+    intToUtf8(127397 + strtoi(charToRaw(toupper(country_code)), 16L))
+  }) |>
+    as.vector()
+}
+
+css <- sass(sass_file("style.scss"))
+
+ui <- fluidPage(
+  tags$head(tags$style(css)),
+  div(id = "leaderboard_box",
+      div(id = "leaderboard",
+        uiOutput("podium"),
+        reactableOutput("leaderboard")
+        ),
+      div(id = "footer_block",
+        HTML("<strong id='footer_head'>FIFA 2022 Leaderboard</strong>"),
+        br(),
+        HTML("<p id='footer_text'><strong>Based on: </strong>
+             Total Points from the <a href=
+             'http://bit.ly/3WBYCo1'>FIFA Worldcup 2022 Results (Kaggle)
+             dataset</a><br>
+             kaggle.com/datasets/sayanroy729/fifa-worldcup-2022-results
+             </p>")
+      )
+  )
+)
+
+server <- function(input, output, session) {
+
+  leaderboard_data <- reactive({
+
+    data <- read.csv("data/total_points.csv")
+    data <- data[order(data$total_points, decreasing = TRUE), ]
+    data$rank <- seq(1:nrow(data))
+    data$total_points <- NULL
+    data$alpha.2 <- get_flag(data$alpha.2)
+    data$country <- paste(data$country, data$alpha.2, sep = "_")
+    data$alpha.2 <- NULL
+    data
+
+    })
+
+    output$podium <- renderUI({
+
+      top_three <- head(leaderboard_data(), 3)$country
+      top_three <- data.frame(t(data.frame(strsplit(top_three, "_"))))
+      colnames(top_three) <- c("Country", "Flag")
+      rownames(top_three) <- NULL
+
+      countries <- top_three$Country
+      flags <- top_three$Flag
+
+      div(id = "podium",
+          div(id = "second_place",
+              class = "podium_box",
+              div(class = "podium_country",
+                  p(class = "country_flag",
+                    flags[2]),
+                  p(class = "country_label",
+                    countries[2])
+              )
+          ),
+          div(id = "first_place",
+              class = "podium_box",
+              div(class = "podium_country",
+                  p(class = "country_flag",
+                    flags[1]),
+                  p(class = "country_label",
+                    countries[1])
+              )
+          ),
+          div(id = "third_place",
+              class = "podium_box",
+              div(class = "podium_country",
+                  p(class = "country_flag",
+                    flags[3]),
+                  p(class = "country_label",
+                    countries[3])
+              )
+          ),
+      )
+    })
+
+    output$leaderboard <- renderReactable({
+      reactable(data = leaderboard_data()[4:10, ],
+                style = list(backgroundColor = "rgba(255, 255, 255, 0.4)"),
+                borderless = TRUE,
+                outlined = FALSE,
+                striped = TRUE,
+                pagination = FALSE,
+                width = "100%",
+                columns = list(
+                  country = colDef(
+                    cell = function(value) {
+                      value <- strsplit(value, "_")[[1]]
+                      div(class = "leaderboard_row",
+                          p(class = "country_flag_row",
+                            value[2]),
+                          p(class = "country_label_row",
+                            value[1])
+                      )
+                    }
+                  ),
+                  rank = colDef(
+                    html = TRUE,
+                    cell = function(value) {
+                      value <- paste0("<p class = 'country_rank_row'>",
+                                      value, "<sup>th</sup></p>"
+                      )
+                      value
+                    }
+                  ))
+      )
+    })
+
+}
+
+shinyApp(ui, server)

--- a/reactable/podium_style_leaderboard/style.scss
+++ b/reactable/podium_style_leaderboard/style.scss
@@ -1,0 +1,106 @@
+#leaderboard_box {
+  position: absolute;
+  top: 5%;
+  left: 30%;
+  display: flex;
+  flex-direction: column;
+}
+
+#leaderboard > div > div > div.rt-thead {
+  display: none;
+}
+
+#podium {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  flex: 1;
+}
+
+.podium_box {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  justify-content: center;
+}
+
+#first_place {
+  background-image: linear-gradient(to bottom right, #ffd700, #ffd700, #ffee96, #ffd700, #ffd700);
+  height: 6em;
+
+  & .podium_country {
+    margin-top: 1em;
+  }
+}
+
+#second_place {
+  background-image: linear-gradient(to bottom right, #c0c0c0, #c0c0c0, #e3e3e3, #c0c0c0, #c0c0c0);
+  height: 5em;
+
+  & .podium_country {
+    margin-top: 0.75em;
+  }
+}
+
+#third_place {
+  background-image: linear-gradient(to bottom right, #cd7f32, #cd7f32, #e39a52, #cd7f32, #cd7f32);
+  height: 4.5em;
+
+  & .podium_country {
+    margin-top: 1em;
+  }
+}
+
+.country_label {
+  position: relative;
+  transform: translateY(-75%);
+  text-align: center;
+  align-items: center;
+  font-size: 0.75em;
+  font-weight: 600;
+}
+
+.country_flag {
+  font-size: 2em;
+  text-align: center;
+}
+
+.country_flag_row {
+  font-size: 1em;
+  text-align: center;
+}
+
+.country_label_row {
+  font-size: 0.75em;
+  font-weight: 600;
+}
+
+.country_rank_row {
+  font-size: 1em;
+  font-weight: 600;
+  margin-top: 1em;
+}
+
+.leaderboard_row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25em;
+  margin-top: 1em;
+}
+
+#footer_block {
+  margin-top: 0.5em;
+}
+
+#footer_head {
+  color: slategray;
+  font-size: 1em;
+}
+
+#footer_text {
+  color: grey;
+  margin-top: 0.25em;
+  font-size: 0.75em;
+}


### PR DESCRIPTION
Adds a simple example for producing a podium-style reactable for the FIFA World Cup 2022 data from [Kaggle](https://kaggle.com/datasets/sayanroy729/fifa-worldcup-2022-results).

<img width="780" alt="Screenshot 2022-12-22 at 6 09 48 PM" src="https://user-images.githubusercontent.com/26517718/209138871-0e9de043-7ded-4738-a8f9-bbd0b4b9f17f.png">
